### PR TITLE
Fix bug in Task.__getattr__

### DIFF
--- a/pytodotxt/todotxt.py
+++ b/pytodotxt/todotxt.py
@@ -183,7 +183,7 @@ class Task:
                 fallback = []
             _, attrname = name.split('_', 1)
             return self.attributes.get(attrname, fallback)
-        return AttributeError(name)
+        raise AttributeError(name)
 
     def parse_attributes(self):
         self._attributes = {}

--- a/tests/test_pytodotxt.py
+++ b/tests/test_pytodotxt.py
@@ -161,6 +161,8 @@ class TestFormats(unittest.TestCase):
         self.assertEqual(len(task.attr_many), 2)
         self.assertEqual(len(task.attr_fancy), 1)
         self.assertEqual(len(task.attr_not_here), 0)
+        with self.assertRaises(AttributeError):
+            _ = task.not_here
 
 
 class TestManipulation(unittest.TestCase):


### PR DESCRIPTION
Hi,
Thanks for sharing this module! I started using it yesterday and fixed a small bug. Feel free to accept or reject this.

Changelist:

- `Task.__getattr__` now raises `AttributeError` instead of returning it.
- `TestFormats.test_convenient_attr_parsing` now contains a test for this condition.

Cheers,
Sander