### PR TITLE
Fix bug with remove attribute

### DIFF
--- a/pytodotxt/task.py
+++ b/pytodotxt/task.py
@@ -128,20 +128,14 @@ class Task:
         success = False
         while True:
             key_found = False
-
             for match in self.parse_tags(type(self).KEYVALUE_RE):
-                if key != match.group(2):
-                    continue
-
-                key_found = True
-
-                if value is None or match.group(3) == value:
+                if key == match.group(2) and (value == match.group(3) or value is None):
+                    key_found = True
                     start, end = match.span()
                     self.description = self.description[:start] + self.description[end:]
                     self.parse(str(self))
                     success = True
-
-                break
+                    break
 
             if not key_found:
                 break

--- a/pytodotxt/task.py
+++ b/pytodotxt/task.py
@@ -136,8 +136,8 @@ class Task:
                 key_found = True
 
                 if value is None or match.group(3) == value:
-                    start, _ = match.span()
-                    self.description = self.description[:start]
+                    start, end = match.span()
+                    self.description = self.description[:start] + self.description[end:]
                     self.parse(str(self))
                     success = True
 


### PR DESCRIPTION
Fixed a bug with remove attribute.

Reproduce:
```
from pytodotxt import Task

task = Task('(C) test t:2022-10-26 due:2022-10-27 t:2022-10-27 @17')
task.remove_attribute('t','2022-10-26')
print(task)
```

Current results (wrong):
```
(C) test
```

After PR merged (correct):
```
(C) test due:2022-10-27 t:2022-10-27 @17
```